### PR TITLE
Clone boxes tensor to avoid mutating ground truth

### DIFF
--- a/datagen.py
+++ b/datagen.py
@@ -77,8 +77,8 @@ class ListDataset(data.Dataset):
         img = Image.open(os.path.join(self.root, fname))
         if img.mode != 'RGB':
             img = img.convert('RGB')
-            
-        boxes = self.boxes[idx]
+
+        boxes = self.boxes[idx].clone()
         labels = self.labels[idx]
         size = self.input_size
 


### PR DESCRIPTION
This resolves an issue where an items bounding box ground truths were being assigned by reference and mutated each time the datum is encoded. This resulted in inputs eventually having 0 width, so there would be no iou matches and loc loss would go to 0